### PR TITLE
Add integrity checks for .tmdz validation in CLI

### DIFF
--- a/tmd-cli/src/main.rs
+++ b/tmd-cli/src/main.rs
@@ -1,4 +1,8 @@
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use std::fs;
+use std::path::Path;
+use tmd_core::TmdDoc;
 
 #[derive(Parser)]
 #[command(name = "tmd", version, about = "Tanu Markdown CLI")]
@@ -9,23 +13,88 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    New { path: String, #[arg(long)] title: Option<String> },
-    Add { doc: String, src: String, #[arg(long)] as_path: String, #[arg(long)] mime: Option<String> },
-    Ls { doc: String },
-    Validate { doc: String },
-    ExportHtml { doc: String, out: String, #[arg(long)] self_contained: bool },
-    ConvertTmdz { doc: String, out: String },
+    New {
+        path: String,
+        #[arg(long)]
+        title: Option<String>,
+    },
+    Add {
+        doc: String,
+        src: String,
+        #[arg(long)]
+        as_path: String,
+        #[arg(long)]
+        mime: Option<String>,
+    },
+    Ls {
+        doc: String,
+    },
+    Validate {
+        doc: String,
+    },
+    ExportHtml {
+        doc: String,
+        out: String,
+        #[arg(long)]
+        self_contained: bool,
+    },
+    ConvertTmdz {
+        doc: String,
+        out: String,
+    },
 }
 
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Commands::New { path, title } => println!("(MVP stub) Create new: {} title={:?}", path, title),
-        Commands::Add { doc, src, as_path, mime } => println!("(MVP stub) Add attachment to {} from {} as {} mime={:?}", doc, src, as_path, mime),
+        Commands::New { path, title } => {
+            println!("(MVP stub) Create new: {} title={:?}", path, title)
+        }
+        Commands::Add {
+            doc,
+            src,
+            as_path,
+            mime,
+        } => println!(
+            "(MVP stub) Add attachment to {} from {} as {} mime={:?}",
+            doc, src, as_path, mime
+        ),
         Commands::Ls { doc } => println!("(MVP stub) List attachments in {}", doc),
-        Commands::Validate { doc } => println!("(MVP stub) Validate {}", doc),
-        Commands::ExportHtml { doc, out, self_contained } => println!("(MVP stub) Export HTML from {} to {} selfContained={}", doc, out, self_contained),
+        Commands::Validate { doc } => validate_command(&doc)?,
+        Commands::ExportHtml {
+            doc,
+            out,
+            self_contained,
+        } => println!(
+            "(MVP stub) Export HTML from {} to {} selfContained={}",
+            doc, out, self_contained
+        ),
         Commands::ConvertTmdz { doc, out } => println!("(MVP stub) Convert {} -> {}", doc, out),
     }
     Ok(())
+}
+
+fn validate_command(doc: &str) -> Result<()> {
+    let path = Path::new(doc);
+    let document = load_document(path)?;
+    println!(
+        "{}: OK (title: {})",
+        path.display(),
+        document.manifest.title
+    );
+    Ok(())
+}
+
+fn load_document(path: &Path) -> Result<TmdDoc> {
+    let bytes = fs::read(path).with_context(|| format!("failed to read `{}`", path.display()))?;
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("tmd") => TmdDoc::open_bytes(&bytes),
+        Some("tmdz") => TmdDoc::from_tmdz_bytes(&bytes),
+        _ => anyhow::bail!("unsupported document extension for `{}`", path.display()),
+    }
 }


### PR DESCRIPTION
### Summary

- Ensure the CLI validate command exercises the same attachment integrity checks for `.tmd` and `.tmdz` documents.
- Factor shared manifest/attachment readers in `tmd-core` and add a `.tmdz` loader that enforces size/hash validation.

### Changes

* Added helper routines in `tmd-core` to validate ZIP contents and exposed `TmdDoc::from_tmdz_bytes` with unit coverage for truncated attachments.
* Updated the CLI validate command to load documents through the new API and report success only after integrity checks pass.

### Validation

* [x] Built successfully
* [x] Tested with sample.tmd


------
https://chatgpt.com/codex/tasks/task_e_68e8c5b92b70832888c25298ca6e8e85