### PR TITLE
Add Docker-based development environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "name": "Tanu Markdown",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": ".."
+  },
+  "remoteUser": "vscode",
+  "workspaceFolder": "/workspace/tanu-markdown",
+  "features": {},
+  "mounts": [
+    "source=${localWorkspaceFolder},target=/workspace/tanu-markdown,type=bind,consistency=cached"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "serayuzgur.crates",
+        "tamasfe.even-better-toml",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "rust-analyzer.cargo.features": "all",
+        "editor.formatOnSave": true
+      }
+    }
+  },
+  "postCreateCommand": "cargo --version && npm --version && rustup component add rustfmt clippy && cd tmd-vscode && npm install",
+  "containerEnv": {
+    "CARGO_HOME": "/usr/local/cargo",
+    "RUSTUP_HOME": "/usr/local/rustup"
+  }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Ignore build outputs and editor settings when building the dev image.
+**/target
+**/node_modules
+.git
+.gitignore
+.vscode
+.idea
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1.5
+FROM mcr.microsoft.com/devcontainers/rust-node:1-22-bullseye
+
+# Install additional build tooling and libraries used across the workspace.
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libsqlite3-dev \
+        libssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pre-create cargo target and npm cache directories to avoid permission mismatches
+# when mounting from the host.
+RUN mkdir -p /workspace /workspaces /usr/local/cargo/registry /usr/local/cargo/git
+
+# Set default working directory used by docker-compose and devcontainers.
+WORKDIR /workspace
+
+# Use the non-root "vscode" user that ships with the base image for day-to-day work.
+USER vscode
+
+# Ensure cargo installs go into the standard location for the vscode user.
+ENV CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup
+
+# Default command keeps the container alive for interactive shells.
+CMD ["sleep", "infinity"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,25 @@ Each `.tmd` file combines **Markdown text + embedded assets + metadata (manifest
 
 ---
 
+## 🛠 Development Environment
+
+### Run everything in Docker
+
+The repository ships with a ready-to-use development image. Build it once and start an interactive shell:
+
+```bash
+docker compose build
+docker compose run --rm dev bash
+```
+
+Rust, Cargo, Node.js and the TypeScript toolchain are available in the container. Workspace volumes are mounted so edits on the host are reflected instantly.
+
+### VS Code Dev Container
+
+When using VS Code, install the **Dev Containers** extension and choose **“Open Folder in Container…”**. The `.devcontainer` configuration provisions the same image, installs `rustfmt`/`clippy`, and runs `npm install` for the VSCode extension automatically.
+
+---
+
 ## 🧩 File Format Overview
 
 ### `.tmd` — Polyglot Format (Markdown + ZIP)

--- a/README_JP.md
+++ b/README_JP.md
@@ -19,6 +19,25 @@ TMD は `.tmd` 拡張子を持ち、1 つのファイルに **Markdown本文 + �
 
 ---
 
+## 🛠 開発環境
+
+### Docker でまとめて構築する
+
+リポジトリには開発用の Docker イメージが含まれています。以下のコマンドでビルドし、対話的なシェルを起動できます。
+
+```bash
+docker compose build
+docker compose run --rm dev bash
+```
+
+Rust / Cargo / Node.js / TypeScript など必要なツールが揃っており、ワークスペースはホストとマウントされます。
+
+### VS Code Dev Container
+
+VS Code の **Dev Containers** 拡張機能を利用すると、同じイメージを使ってフォルダーを直接コンテナー内で開けます。`.devcontainer` の設定により `rustfmt` / `clippy` のインストールと、VSCode 拡張向けの `npm install` が自動で実行されます。
+
+---
+
 ## 🧩 ファイル形式概要
 
 ### `.tmd` — Polyglot 形式 (Markdown + ZIP)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/workspace/tanu-markdown:cached
+      - cargo-cache:/usr/local/cargo
+      - rustup-cache:/usr/local/rustup
+    working_dir: /workspace/tanu-markdown
+    user: "vscode"
+    tty: true
+    init: true
+    command: ["sleep", "infinity"]
+
+volumes:
+  cargo-cache:
+  rustup-cache:


### PR DESCRIPTION
### Summary
- add a reusable Docker image that bundles the Rust and Node.js toolchains for the project
- provide docker-compose and Dev Container configs so contributors can start the environment quickly
- document how to use the containerized setup in both English and Japanese READMEs

### Changes
* new Dockerfile, docker-compose manifest, and .dockerignore for development workflows
* VS Code Dev Container configuration with recommended extensions and post-create setup
* README updates describing Docker and Dev Container usage

### Validation
* [ ] Built successfully
* [ ] Tested with sample.tmd

------
https://chatgpt.com/codex/tasks/task_e_68ed8fb02f2883289b10a81f88651932