### PR TITLE
[tmd-core] Implement SQLite-integrated document API

### DIFF
--- a/tmd-core/Cargo.toml
+++ b/tmd-core/Cargo.toml
@@ -10,3 +10,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 zip = { version = "0.6", default-features = false, features = ["deflate", "time", "aes-crypto"] }
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1", features = ["serde", "v4"] }
+mime = "0.3"
+rusqlite = { version = "0.29", features = ["bundled"] }
+tempfile = "3"
+hex = "0.4"


### PR DESCRIPTION
### Summary
- implement the v0.2 TMD document API with manifest, attachments, and SQLite database support
- provide reader/writer helpers for .tmd and .tmdz containers plus utility functions
- add comprehensive unit coverage for the exported API surface

### Changes
* restructured `tmd-core` into module-based API with manifest, attachment store, database utilities, and format helpers
* added SQLite handle management, attachment management, and format read/write implementations with JSON manifests and attachments metadata
* introduced extensive unit tests covering document creation, DB helpers, attachment lifecycle, and read/write round-trips

### Validation
* [x] `cargo fmt`
* [x] `cargo test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117703e18c83288e72c5df212ff736)