### PR TITLE
Update CLI for embedded database workflows

### DIFF
--- a/tmd-cli/Cargo.lock
+++ b/tmd-cli/Cargo.lock
@@ -32,6 +32,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +136,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +162,20 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "cipher"
@@ -197,6 +238,12 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -264,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.3.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -334,13 +381,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown",
 ]
@@ -350,6 +398,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -367,6 +421,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
 dependencies = [
  "utf8-width",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -391,6 +469,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,9 +486,9 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
  "cc",
  "pkg-config",
@@ -414,10 +502,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -434,6 +534,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -526,9 +635,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -550,6 +659,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -725,11 +840,7 @@ dependencies = [
  "html-escape",
  "pulldown-cmark",
  "rusqlite",
- "serde_json",
- "sha2",
- "tempfile",
  "tmd-core",
- "zip",
 ]
 
 [[package]]
@@ -737,10 +848,16 @@ name = "tmd-core"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "chrono",
+ "hex",
+ "mime",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror",
+ "uuid",
  "zip",
 ]
 
@@ -781,6 +898,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,10 +931,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/tmd-cli/Cargo.toml
+++ b/tmd-cli/Cargo.toml
@@ -7,11 +7,7 @@ edition = "2021"
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 tmd-core = { path = "../tmd-core" }
-serde_json = "1"
-zip = { version = "0.6", default-features = false, features = ["deflate", "time", "aes-crypto"] }
 pulldown-cmark = "0.9"
 base64 = "0.21"
 html-escape = "0.2"
-rusqlite = { version = "0.31", features = ["bundled"] }
-tempfile = "3"
-sha2 = "0.10"
+rusqlite = { version = "0.29", features = ["bundled"] }

--- a/tmd-cli/src/main.rs
+++ b/tmd-cli/src/main.rs
@@ -1,23 +1,16 @@
 //! Tanu Markdown CLI entrypoint.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
-use std::fs::File;
-use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
 use clap::{Parser, Subcommand};
 use html_escape::encode_text;
 use pulldown_cmark::{html, Options, Parser as MdParser};
-use rusqlite::{types::Value as SqlValue, Connection, OpenFlags};
-use sha2::{Digest, Sha256};
-use tempfile::NamedTempFile;
-use tmd_core::{Manifest, TmdDoc};
-use zip::write::FileOptions;
-use zip::{CompressionMethod, ZipArchive, ZipWriter};
+use rusqlite::types::Value as SqlValue;
+use tmd_core::{export_db, import_db, read_from_path, reset_db, write_to_path, Format, TmdDoc};
 
 #[derive(Parser)]
 #[command(name = "tmd", version, about = "Tanu Markdown CLI")]
@@ -28,123 +21,138 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Scaffold a new TMD workspace directory.
+    /// Create a new `.tmd` or `.tmdz` document with an embedded SQLite database.
     New {
-        path: String,
+        output: PathBuf,
         #[arg(long)]
         title: Option<String>,
     },
-    /// Pack a `.tmd` document from a directory or `.tmdz` archive.
-    Pack { input: String, output: String },
-    /// Unpack a `.tmd` document into a directory or `.tmdz` archive.
-    Unpack { input: String, output: String },
+    /// Convert between `.tmd` and `.tmdz` containers.
+    Convert { input: PathBuf, output: PathBuf },
     /// Validate a `.tmd` or `.tmdz` document.
-    Validate { input: String },
+    Validate { input: PathBuf },
     /// Export a `.tmd`/`.tmdz` document to HTML.
     ExportHtml {
-        input: String,
-        output: String,
+        input: PathBuf,
+        output: PathBuf,
         #[arg(long)]
         self_contained: bool,
     },
-    /// Execute a read-only SQL query against the embedded SQLite database.
-    Query {
-        input: String,
+    /// Database maintenance commands.
+    Db {
+        #[command(subcommand)]
+        command: DbCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum DbCommands {
+    /// Initialise or reset the embedded database schema.
+    Init {
+        doc: PathBuf,
+        #[arg(long)]
+        schema: Option<PathBuf>,
+        #[arg(long)]
+        version: Option<u32>,
+    },
+    /// Execute SQL against the embedded database.
+    Exec {
+        doc: PathBuf,
         #[arg(long)]
         sql: String,
     },
+    /// Import a SQLite file, replacing the embedded database.
+    Import { doc: PathBuf, source: PathBuf },
+    /// Export the embedded SQLite database to a standalone file.
+    Export { doc: PathBuf, output: PathBuf },
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Commands::New { path, title } => cmd_new(Path::new(&path), title.as_deref()),
-        Commands::Pack { input, output } => cmd_pack(Path::new(&input), Path::new(&output)),
-        Commands::Unpack { input, output } => cmd_unpack(Path::new(&input), Path::new(&output)),
-        Commands::Validate { input } => cmd_validate(Path::new(&input)),
+        Commands::New { output, title } => cmd_new(&output, title.as_deref()),
+        Commands::Convert { input, output } => cmd_convert(&input, &output),
+        Commands::Validate { input } => cmd_validate(&input),
         Commands::ExportHtml {
             input,
             output,
             self_contained,
-        } => cmd_export_html(Path::new(&input), Path::new(&output), self_contained),
-        Commands::Query { input, sql } => cmd_query(Path::new(&input), &sql),
+        } => cmd_export_html(&input, &output, self_contained),
+        Commands::Db { command } => match command {
+            DbCommands::Init {
+                doc,
+                schema,
+                version,
+            } => cmd_db_init(&doc, schema.as_deref(), version),
+            DbCommands::Exec { doc, sql } => cmd_db_exec(&doc, &sql),
+            DbCommands::Import { doc, source } => cmd_db_import(&doc, &source),
+            DbCommands::Export { doc, output } => cmd_db_export(&doc, &output),
+        },
     }
 }
 
 fn cmd_new(path: &Path, title: Option<&str>) -> Result<()> {
-    anyhow::ensure!(
-        !path.exists(),
-        "target directory `{}` already exists",
+    anyhow::ensure!(!path.exists(), "target `{}` already exists", path.display());
+    ensure_parent_directory(path)?;
+
+    let format = detect_format(path)?;
+    let display_title = title.unwrap_or("New TMD Document");
+    let markdown = format!(
+        "# {}\n\nWelcome to **Tanu Markdown**!\n\nThe embedded database is ready for use.",
+        display_title
+    );
+    let mut doc = TmdDoc::new(markdown).context("failed to create document")?;
+    doc.manifest.title = Some(display_title.to_string());
+    doc.touch();
+
+    write_document(path, &doc, format)?;
+    println!(
+        "Created new {} document at {}",
+        format_display(format),
         path.display()
     );
-    fs::create_dir_all(path)
-        .with_context(|| format!("failed to create directory `{}`", path.display()))?;
-    fs::create_dir_all(path.join("images")).context("failed to create images directory")?;
-    fs::create_dir_all(path.join("data")).context("failed to create data directory")?;
+    Ok(())
+}
 
-    let title = title.unwrap_or("New TMD Document");
-    let markdown = format!(
-        "# {}\n\nWelcome to **Tanu Markdown**!\n\nStart editing `index.md` to add your content.",
-        title
+fn cmd_convert(input: &Path, output: &Path) -> Result<()> {
+    let (doc, _) = read_document(input)?;
+    let format = detect_format(output)?;
+    ensure_parent_directory(output)?;
+    write_document(output, &doc, format)?;
+    println!(
+        "Converted `{}` into `{}`",
+        input.display(),
+        output.display()
     );
-    fs::write(path.join("index.md"), markdown).context("failed to write initial index.md")?;
-
-    let manifest = serde_json::json!({
-        "version": 1,
-        "schemaVersion": "2025.10",
-        "title": title,
-        "attachments": {},
-        "data": {
-            "engine": "none",
-            "entry": ""
-        }
-    });
-
-    fs::write(
-        path.join("manifest.json"),
-        serde_json::to_string_pretty(&manifest)? + "\n",
-    )
-    .context("failed to write manifest.json")?;
-
-    println!("Initialized new TMD workspace at {}", path.display());
-    Ok(())
-}
-
-fn cmd_pack(input: &Path, output: &Path) -> Result<()> {
-    let doc = load_document(input)?;
-    doc.write_to_path(output)
-        .with_context(|| format!("failed to write `{}`", output.display()))?;
-    println!("Packed `{}` into `{}`", input.display(), output.display());
-    Ok(())
-}
-
-fn cmd_unpack(input: &Path, output: &Path) -> Result<()> {
-    let doc = load_document(input)?;
-    if output
-        .extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("tmdz"))
-    {
-        write_tmdz(&doc, output)?;
-    } else if output
-        .extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("tmd"))
-    {
-        doc.write_to_path(output)?;
-    } else {
-        write_directory(&doc, output)?;
-    }
-    println!("Unpacked `{}` into `{}`", input.display(), output.display());
     Ok(())
 }
 
 fn cmd_validate(input: &Path) -> Result<()> {
-    let _doc = load_document(input)?;
-    println!("{} is valid", input.display());
+    let (doc, _) = read_document(input)?;
+    let user_version = doc
+        .db_with_conn(|conn| conn.query_row("PRAGMA user_version", [], |row| row.get::<_, u32>(0)))
+        .context("failed to access embedded database")?
+        .context("failed to read PRAGMA user_version from embedded database")?;
+
+    if let Some(expected) = doc.manifest.db_schema_version {
+        anyhow::ensure!(
+            expected == user_version,
+            "manifest db_schema_version={} but PRAGMA user_version={}",
+            expected,
+            user_version
+        );
+    }
+
+    println!(
+        "{} is valid (user_version = {})",
+        input.display(),
+        user_version
+    );
     Ok(())
 }
 
 fn cmd_export_html(input: &Path, output: &Path, self_contained: bool) -> Result<()> {
-    let doc = load_document(input)?;
+    let (doc, _) = read_document(input)?;
     let mut options = Options::empty();
     options.insert(Options::ENABLE_TABLES);
     options.insert(Options::ENABLE_TASKLISTS);
@@ -157,6 +165,12 @@ fn cmd_export_html(input: &Path, output: &Path, self_contained: bool) -> Result<
     } else {
         render_attachment_listing(&doc)
     };
+
+    let title = doc
+        .manifest
+        .title
+        .as_deref()
+        .unwrap_or("Tanu Markdown Document");
 
     let html = format!(
         r#"<!DOCTYPE html>
@@ -180,11 +194,12 @@ fn cmd_export_html(input: &Path, output: &Path, self_contained: bool) -> Result<
   </body>
 </html>
 "#,
-        title = encode_text(&doc.manifest.title),
+        title = encode_text(title),
         body = body_html,
         attachments = attachment_section,
     );
 
+    ensure_parent_directory(output)?;
     fs::write(output, html).with_context(|| format!("failed to write `{}`", output.display()))?;
     println!(
         "Exported `{}` to HTML at `{}`",
@@ -194,64 +209,216 @@ fn cmd_export_html(input: &Path, output: &Path, self_contained: bool) -> Result<
     Ok(())
 }
 
-fn cmd_query(input: &Path, sql: &str) -> Result<()> {
-    let doc = load_document(input)?;
-    anyhow::ensure!(
-        doc.manifest.data.engine.eq_ignore_ascii_case("sqlite"),
-        "document does not declare a SQLite data section"
-    );
-    let entry = PathBuf::from(&doc.manifest.data.entry);
-    let entry_str = entry
-        .to_str()
-        .with_context(|| "data entry path is not valid UTF-8")?;
-    let attachment = doc
-        .attachments
-        .get(entry_str)
-        .with_context(|| format!("attachment `{}` not found", entry.display()))?;
-    anyhow::ensure!(
-        !attachment.is_empty(),
-        "attachment `{}` is empty; nothing to query",
-        entry.display()
-    );
+fn cmd_db_init(doc_path: &Path, schema_path: Option<&Path>, version: Option<u32>) -> Result<()> {
+    let (mut doc, format) = read_document(doc_path)?;
+    let schema_sql = if let Some(path) = schema_path {
+        Some(
+            fs::read_to_string(path)
+                .with_context(|| format!("failed to read schema `{}`", path.display()))?,
+        )
+    } else {
+        None
+    };
 
-    let mut temp = NamedTempFile::new().context("failed to create temporary SQLite file")?;
-    temp.write_all(attachment)
-        .context("failed to write SQLite data to temporary file")?;
-    let temp_path = temp.into_temp_path();
+    if let Some(sql) = schema_sql.as_deref() {
+        let version = version.unwrap_or(0);
+        reset_db(&mut doc, sql, version).context("failed to reset embedded database")?;
+        doc.manifest.db_schema_version = Some(version);
+        doc.touch();
+    } else if let Some(version) = version {
+        doc.db_with_conn_mut(|conn| -> rusqlite::Result<()> {
+            conn.pragma_update(None, "user_version", version as i64)?;
+            Ok(())
+        })
+        .context("failed to access embedded database")?
+        .context("failed to update database version")?;
+        doc.manifest.db_schema_version = Some(version);
+        doc.touch();
+    }
 
-    let conn = Connection::open_with_flags(&temp_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
-        .context("failed to open SQLite database")?;
-    let mut stmt = conn
-        .prepare(sql)
-        .with_context(|| "failed to prepare SQL statement")?;
-    let column_count = stmt.column_count();
-    let column_names: Vec<String> = stmt
-        .column_names()
-        .into_iter()
-        .map(|name| name.to_string())
-        .collect();
-
-    println!("| {} |", column_names.join(" | "));
+    write_document(doc_path, &doc, format)?;
     println!(
-        "|{}|",
-        column_names
-            .iter()
-            .map(|_| "---")
-            .collect::<Vec<_>>()
-            .join("|")
+        "Initialised database for `{}` (schema version = {:?})",
+        doc_path.display(),
+        doc.manifest.db_schema_version
     );
+    Ok(())
+}
 
-    let mut rows = stmt.query([]).with_context(|| "failed to execute query")?;
-    while let Some(row) = rows.next()? {
-        let mut values = Vec::with_capacity(column_count);
-        for idx in 0..column_count {
-            let value: SqlValue = row.get(idx)?;
-            values.push(display_sql_value(&value));
-        }
-        println!("| {} |", values.join(" | "));
+fn cmd_db_exec(doc_path: &Path, sql: &str) -> Result<()> {
+    let (mut doc, format) = read_document(doc_path)?;
+    let trimmed = sql.trim_start();
+    let lowered = trimmed
+        .chars()
+        .take(16)
+        .collect::<String>()
+        .to_ascii_lowercase();
+    let looks_like_query = lowered.starts_with("select")
+        || lowered.starts_with("pragma")
+        || lowered.starts_with("with");
+
+    if looks_like_query {
+        doc.db_with_conn(|conn| -> rusqlite::Result<()> {
+            let mut stmt = conn.prepare(sql)?;
+            let column_count = stmt.column_count();
+            let column_names: Vec<String> = stmt
+                .column_names()
+                .into_iter()
+                .map(|name| name.to_string())
+                .collect();
+
+            if column_count > 0 {
+                println!("| {} |", column_names.join(" | "));
+                println!(
+                    "|{}|",
+                    column_names
+                        .iter()
+                        .map(|_| "---")
+                        .collect::<Vec<_>>()
+                        .join("|")
+                );
+            }
+
+            let mut rows = stmt.query([])?;
+            while let Some(row) = rows.next()? {
+                let mut values = Vec::with_capacity(column_count);
+                for idx in 0..column_count {
+                    let value: SqlValue = row.get(idx)?;
+                    values.push(display_sql_value(&value));
+                }
+                println!("| {} |", values.join(" | "));
+            }
+            Ok(())
+        })
+        .context("failed to access embedded database")?
+        .context("failed to execute query")?;
+    } else {
+        doc.db_with_conn_mut(|conn| -> rusqlite::Result<()> {
+            conn.execute_batch(sql)?;
+            Ok(())
+        })
+        .context("failed to access embedded database")?
+        .context("failed to execute SQL against embedded database")?;
+        doc.touch();
+        write_document(doc_path, &doc, format)?;
+        println!("Executed SQL and updated `{}`", doc_path.display());
+        return Ok(());
     }
 
     Ok(())
+}
+
+fn cmd_db_import(doc_path: &Path, source: &Path) -> Result<()> {
+    let (mut doc, format) = read_document(doc_path)?;
+    import_db(&mut doc, source).context("failed to import SQLite database")?;
+    let user_version = doc
+        .db_with_conn(|conn| conn.query_row("PRAGMA user_version", [], |row| row.get::<_, u32>(0)))
+        .context("failed to access embedded database")?
+        .context("failed to query imported user_version")?;
+    doc.manifest.db_schema_version = Some(user_version);
+    doc.touch();
+    write_document(doc_path, &doc, format)?;
+    println!(
+        "Imported database from `{}` into `{}` (user_version = {})",
+        source.display(),
+        doc_path.display(),
+        user_version
+    );
+    Ok(())
+}
+
+fn cmd_db_export(doc_path: &Path, output: &Path) -> Result<()> {
+    let (doc, _) = read_document(doc_path)?;
+    ensure_parent_directory(output)?;
+    export_db(&doc, output).context("failed to export embedded database")?;
+    println!(
+        "Exported embedded database from `{}` to `{}`",
+        doc_path.display(),
+        output.display()
+    );
+    Ok(())
+}
+
+fn read_document(path: &Path) -> Result<(TmdDoc, Format)> {
+    let format = detect_format(path)?;
+    let doc = read_from_path(path, Some(format))
+        .with_context(|| format!("failed to read `{}`", path.display()))?;
+    Ok((doc, format))
+}
+
+fn write_document(path: &Path, doc: &TmdDoc, format: Format) -> Result<()> {
+    write_to_path(path, doc, format)
+        .with_context(|| format!("failed to write `{}`", path.display()))
+}
+
+fn detect_format(path: &Path) -> Result<Format> {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("tmd") => Ok(Format::Tmd),
+        Some("tmdz") => Ok(Format::Tmdz),
+        _ => Err(anyhow!(
+            "unsupported path `{}` — expected extension .tmd or .tmdz",
+            path.display()
+        )),
+    }
+}
+
+fn ensure_parent_directory(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create directory `{}`", parent.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn render_attachment_listing(doc: &TmdDoc) -> String {
+    let mut metas: Vec<_> = doc.list_attachments().collect();
+    if metas.is_empty() {
+        return String::new();
+    }
+    metas.sort_by(|a, b| a.logical_path.cmp(&b.logical_path));
+
+    let mut rows = String::new();
+    rows.push_str("<section><h2>Attachments</h2><ul>\n");
+    for meta in metas {
+        rows.push_str(&format!(
+            "  <li><code>{name}</code> ({size} bytes, {mime})</li>\n",
+            name = encode_text(&meta.logical_path),
+            size = meta.length,
+            mime = encode_text(meta.mime.as_ref()),
+        ));
+    }
+    rows.push_str("</ul></section>");
+    rows
+}
+
+fn render_embedded_attachments(doc: &TmdDoc) -> String {
+    let mut entries: Vec<_> = doc.attachments.iter_with_data().collect();
+    if entries.is_empty() {
+        return String::new();
+    }
+    entries.sort_by(|(a, _), (b, _)| a.logical_path.cmp(&b.logical_path));
+
+    let mut out = String::new();
+    out.push_str("<section><h2>Attachments</h2><ul>\n");
+    for (meta, data) in entries {
+        let encoded = BASE64_STANDARD.encode(data);
+        let href = format!("data:{};base64,{}", meta.mime, encoded);
+        out.push_str(&format!(
+            "  <li><a download=\"{name}\" href=\"{href}\">{name}</a> ({size} bytes)</li>\n",
+            name = encode_text(&meta.logical_path),
+            href = href,
+            size = meta.length
+        ));
+    }
+    out.push_str("</ul></section>");
+    out
 }
 
 fn display_sql_value(value: &SqlValue) -> String {
@@ -264,235 +431,9 @@ fn display_sql_value(value: &SqlValue) -> String {
     }
 }
 
-fn load_document(path: &Path) -> Result<TmdDoc> {
-    if path.is_dir() {
-        return load_from_directory(path);
+fn format_display(format: Format) -> &'static str {
+    match format {
+        Format::Tmd => ".tmd",
+        Format::Tmdz => ".tmdz",
     }
-    match path
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .map(|ext| ext.to_ascii_lowercase())
-        .as_deref()
-    {
-        Some("tmd") => {
-            let bytes =
-                fs::read(path).with_context(|| format!("failed to read `{}`", path.display()))?;
-            TmdDoc::open_bytes(&bytes)
-        }
-        Some("tmdz") => load_from_tmdz(path),
-        _ => anyhow::bail!(
-            "unsupported input `{}` — expected directory, .tmd, or .tmdz",
-            path.display()
-        ),
-    }
-}
-
-fn load_from_directory(path: &Path) -> Result<TmdDoc> {
-    let markdown_path = path.join("index.md");
-    let manifest_path = path.join("manifest.json");
-    let markdown = fs::read_to_string(&markdown_path)
-        .with_context(|| format!("failed to read markdown at `{}`", markdown_path.display()))?;
-    let manifest_json = fs::read_to_string(&manifest_path)
-        .with_context(|| format!("failed to read manifest at `{}`", manifest_path.display()))?;
-    let manifest: Manifest =
-        serde_json::from_str(&manifest_json).context("failed to deserialize manifest.json")?;
-
-    let mut attachments = HashMap::new();
-    for path_entry in manifest.attachments.keys() {
-        let file_path = path.join(path_entry);
-        let data = fs::read(&file_path)
-            .with_context(|| format!("failed to read attachment `{}`", file_path.display()))?;
-        attachments.insert(path_entry.clone(), data);
-    }
-
-    Ok(TmdDoc::from_parts(markdown, manifest, attachments))
-}
-
-fn load_from_tmdz(path: &Path) -> Result<TmdDoc> {
-    let file = File::open(path).with_context(|| format!("failed to open `{}`", path.display()))?;
-    let mut archive = ZipArchive::new(file).context("failed to read .tmdz archive")?;
-
-    let markdown = {
-        let mut file = archive
-            .by_name("index.md")
-            .context("index.md missing from archive")?;
-        let mut buf = String::new();
-        file.read_to_string(&mut buf)
-            .context("failed to read index.md")?;
-        buf
-    };
-
-    let manifest: Manifest = {
-        let mut file = archive
-            .by_name("manifest.json")
-            .context("manifest.json missing from archive")?;
-        let mut buf = String::new();
-        file.read_to_string(&mut buf)
-            .context("failed to read manifest.json")?;
-        serde_json::from_str(&buf).context("failed to deserialize manifest.json")?
-    };
-
-    let mut attachments = HashMap::new();
-    let mut seen = HashSet::new();
-    for (path_entry, meta) in &manifest.attachments {
-        let mut file = archive
-            .by_name(path_entry)
-            .with_context(|| format!("attachment `{}` missing from archive", path_entry))?;
-        let mut data = Vec::new();
-        file.read_to_end(&mut data)
-            .with_context(|| format!("failed to read attachment `{}`", path_entry))?;
-
-        anyhow::ensure!(
-            data.len() as u64 == meta.size,
-            "attachment `{}` size mismatch: manifest={} actual={}",
-            path_entry,
-            meta.size,
-            data.len()
-        );
-
-        let digest_hex = sha256_hex(&data);
-        anyhow::ensure!(
-            digest_hex.eq_ignore_ascii_case(&meta.sha256),
-            "attachment `{}` sha256 mismatch: manifest={} actual={}",
-            path_entry,
-            meta.sha256,
-            digest_hex
-        );
-
-        attachments.insert(path_entry.clone(), data);
-        seen.insert(path_entry.clone());
-    }
-
-    for idx in 0..archive.len() {
-        let file = archive
-            .by_index(idx)
-            .with_context(|| format!("failed to inspect ZIP entry at index {}", idx))?;
-        if file.is_dir() {
-            continue;
-        }
-        let name = file.name();
-        if name == "index.md" || name == "manifest.json" {
-            continue;
-        }
-        anyhow::ensure!(
-            seen.contains(name),
-            "ZIP archive contains undeclared entry `{}`",
-            name
-        );
-    }
-
-    Ok(TmdDoc::from_parts(markdown, manifest, attachments))
-}
-
-fn sha256_hex(data: &[u8]) -> String {
-    let digest = Sha256::digest(data);
-    let mut out = String::with_capacity(digest.len() * 2);
-    for byte in digest {
-        use std::fmt::Write as _;
-        // Writing to `String` cannot fail.
-        let _ = write!(&mut out, "{:02x}", byte);
-    }
-    out
-}
-
-fn write_directory(doc: &TmdDoc, output: &Path) -> Result<()> {
-    fs::create_dir_all(output)
-        .with_context(|| format!("failed to create `{}`", output.display()))?;
-    fs::write(output.join("index.md"), &doc.markdown).context("failed to write index.md")?;
-    fs::write(
-        output.join("manifest.json"),
-        serde_json::to_string_pretty(&doc.manifest)? + "\n",
-    )
-    .context("failed to write manifest.json")?;
-
-    for (path_entry, data) in &doc.attachments {
-        let target_path = output.join(path_entry);
-        if let Some(parent) = target_path.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("failed to create directory `{}`", parent.display()))?;
-        }
-        fs::write(&target_path, data)
-            .with_context(|| format!("failed to write attachment `{}`", target_path.display()))?;
-    }
-    Ok(())
-}
-
-fn write_tmdz(doc: &TmdDoc, output: &Path) -> Result<()> {
-    let file =
-        File::create(output).with_context(|| format!("failed to create `{}`", output.display()))?;
-    let mut writer = ZipWriter::new(file);
-    let options = FileOptions::default()
-        .compression_method(CompressionMethod::Stored)
-        .large_file(true);
-
-    writer
-        .start_file("index.md", options)
-        .context("failed to start index.md entry")?;
-    writer
-        .write_all(doc.markdown.as_bytes())
-        .context("failed to write index.md")?;
-
-    writer
-        .start_file("manifest.json", options)
-        .context("failed to start manifest.json entry")?;
-    writer
-        .write_all(serde_json::to_string_pretty(&doc.manifest)?.as_bytes())
-        .context("failed to write manifest.json")?;
-
-    let mut ordered: BTreeMap<&String, &Vec<u8>> = BTreeMap::new();
-    for (path_entry, data) in &doc.attachments {
-        ordered.insert(path_entry, data);
-    }
-
-    for (path_entry, data) in ordered {
-        writer
-            .start_file(path_entry, options)
-            .with_context(|| format!("failed to start attachment `{}`", path_entry))?;
-        writer
-            .write_all(data)
-            .with_context(|| format!("failed to write attachment `{}`", path_entry))?;
-    }
-
-    writer.finish().context("failed to finish ZIP archive")?;
-    Ok(())
-}
-
-fn render_attachment_listing(doc: &TmdDoc) -> String {
-    if doc.attachments.is_empty() {
-        return String::new();
-    }
-    let mut rows = String::new();
-    rows.push_str("<section><h2>Attachments</h2><ul>\n");
-    for (path_entry, meta) in &doc.manifest.attachments {
-        let escaped = encode_text(path_entry);
-        let mime = encode_text(&meta.mime);
-        rows.push_str(&format!(
-            "  <li><code>{}</code> ({} bytes, {})</li>\n",
-            escaped, meta.size, mime
-        ));
-    }
-    rows.push_str("</ul></section>");
-    rows
-}
-
-fn render_embedded_attachments(doc: &TmdDoc) -> String {
-    if doc.attachments.is_empty() {
-        return String::new();
-    }
-    let mut out = String::new();
-    out.push_str("<section><h2>Attachments</h2><ul>\n");
-    for (path_entry, meta) in &doc.manifest.attachments {
-        if let Some(data) = doc.attachments.get(path_entry) {
-            let encoded = BASE64_STANDARD.encode(data);
-            let href = format!("data:{};base64,{}", meta.mime, encoded);
-            out.push_str(&format!(
-                "  <li><a download=\"{name}\" href=\"{href}\">{name}</a> ({size} bytes)</li>\n",
-                name = encode_text(path_entry),
-                href = href,
-                size = meta.size
-            ));
-        }
-    }
-    out.push_str("</ul></section>");
-    out
 }


### PR DESCRIPTION
### Summary
- align the CLI entrypoint with the v0.2 core API that always bundles an embedded SQLite database
- provide new database management subcommands and streamline document conversion/export paths

### Changes
* replace the legacy pack/unpack/query commands with new `new`, `convert`, `validate`, `export-html`, and `db` workflows
* update HTML exporting and attachment handling to use the latest `tmd-core` data model
* drop unused dependencies and match the CLI's `rusqlite` version with the core crate

### Validation
* [x] cargo check --manifest-path tmd-cli/Cargo.toml
* [ ] Tested with sample.tmd


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69128b070bc08328bf96047bc21fc6f1)