### PR TITLE
Ensure tmd-core library target is explicitly defined

### DIFF
--- a/tmd-core/Cargo.toml
+++ b/tmd-core/Cargo.toml
@@ -3,6 +3,10 @@ name = "tmd-core"
 version = "0.0.1"
 edition = "2021"
 
+[lib]
+path = "src/lib.rs"
+crate-type = ["rlib"]
+
 [dependencies]
 anyhow = "1"
 thiserror = "1"


### PR DESCRIPTION
### Summary

Ensure the `tmd-core` crate explicitly identifies the source file for its library target so the rlib build configuration remains stable for future changes.

### Changes

* Declare `path = "src/lib.rs"` inside the `[lib]` section of `tmd-core/Cargo.toml` alongside the existing `crate-type` definition.

### Validation

* [x] Built successfully (`cargo test` in `tmd-core`)
* [x] Tested with sample.tmd (`cargo test` in `tmd-cli`)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69152ac1b0d88328b4a6285b8866cc51)