### PR TITLE
[docs] Add README for tmd-cli and tmd-core-ffi crates

### DIFF
--- a/tmd-cli/README.md
+++ b/tmd-cli/README.md
@@ -1,0 +1,77 @@
+# tmd-cli
+
+`tmd-cli` is the command-line interface for working with Tanu Markdown (`.tmd` / `.tmdz`) documents. It creates new documents, converts formats, validates embedded database metadata, exports Markdown to HTML, and manages the embedded SQLite database.
+
+## Build & Run
+
+```bash
+cargo run --manifest-path tmd-cli/Cargo.toml -- --help
+```
+
+If you prefer a release build:
+
+```bash
+cargo build --release --manifest-path tmd-cli/Cargo.toml
+```
+
+## Commands
+
+### Create a New Document
+
+```bash
+cargo run --manifest-path tmd-cli/Cargo.toml -- new ./notes.tmd --title "Project Notes"
+```
+
+Creates a `.tmd` or `.tmdz` document (based on the extension) with a ready-to-use embedded SQLite database.
+
+### Convert Between `.tmd` and `.tmdz`
+
+```bash
+cargo run --manifest-path tmd-cli/Cargo.toml -- convert ./notes.tmd ./notes.tmdz
+```
+
+### Validate a Document
+
+```bash
+cargo run --manifest-path tmd-cli/Cargo.toml -- validate ./notes.tmdz
+```
+
+Validation checks the embedded database schema version in `manifest.db_schema_version` against `PRAGMA user_version`.
+
+### Export HTML
+
+```bash
+cargo run --manifest-path tmd-cli/Cargo.toml -- export-html ./notes.tmdz ./notes.html
+```
+
+To inline attachments as base64 data URIs:
+
+```bash
+cargo run --manifest-path tmd-cli/Cargo.toml -- export-html ./notes.tmdz ./notes.html --self-contained
+```
+
+### Embedded Database Commands
+
+#### Initialize / Reset the DB Schema
+
+```bash
+cargo run --manifest-path tmd-cli/Cargo.toml -- db init ./notes.tmdz --schema ./schema.sql --version 1
+```
+
+#### Execute SQL
+
+```bash
+cargo run --manifest-path tmd-cli/Cargo.toml -- db exec ./notes.tmdz --sql "SELECT name FROM sqlite_master"
+```
+
+#### Import / Export the Database
+
+```bash
+cargo run --manifest-path tmd-cli/Cargo.toml -- db import ./notes.tmdz ./db.sqlite
+cargo run --manifest-path tmd-cli/Cargo.toml -- db export ./notes.tmdz ./db.sqlite
+```
+
+## Notes
+
+- The output format is inferred from the file extension (`.tmd` or `.tmdz`).
+- When the embedded database is updated, the document manifest `modified_utc` timestamp is refreshed automatically.

--- a/tmd-core-ffi/README.md
+++ b/tmd-core-ffi/README.md
@@ -21,7 +21,6 @@ The wrapper keeps the core FFI functions alive so the linker does not drop them.
 - `tmd_doc_new` / `tmd_doc_free`
 - `tmd_doc_read_from_path` / `tmd_doc_write_to_path`
 - `tmd_doc_get_markdown` / `tmd_doc_set_markdown`
-- `tmd_doc_add_attachment` / `tmd_doc_get_attachment`
 - `tmd_last_error_message`
 
 Refer to `tmd-core` for the full FFI contract and error semantics.

--- a/tmd-core-ffi/README.md
+++ b/tmd-core-ffi/README.md
@@ -1,0 +1,32 @@
+# tmd-core-ffi
+
+`tmd-core-ffi` is a small cdylib wrapper around `tmd-core` that preserves the exported C ABI symbols. It enables non-Rust consumers to read/write Tanu Markdown documents via the `tmd-core` FFI surface.
+
+## Build
+
+```bash
+cargo build --release --manifest-path tmd-core-ffi/Cargo.toml
+```
+
+The compiled library will be placed in `tmd-core-ffi/target/release/`:
+
+- Linux: `libtmd_core_ffi.so`
+- macOS: `libtmd_core_ffi.dylib`
+- Windows: `tmd_core_ffi.dll`
+
+## Exported Symbols
+
+The wrapper keeps the core FFI functions alive so the linker does not drop them. The exported API is defined in `tmd-core` under the `ffi` module. Common entry points include:
+
+- `tmd_doc_new` / `tmd_doc_free`
+- `tmd_doc_read_from_path` / `tmd_doc_write_to_path`
+- `tmd_doc_get_markdown` / `tmd_doc_set_markdown`
+- `tmd_doc_add_attachment` / `tmd_doc_get_attachment`
+- `tmd_last_error_message`
+
+Refer to `tmd-core` for the full FFI contract and error semantics.
+
+## Notes
+
+- This crate only exposes a stable C ABI; it does not generate headers.
+- If you need C headers, generate them from the `tmd-core` FFI definitions using a tool like `cbindgen`.


### PR DESCRIPTION
### Motivation

- Provide missing documentation so each crate has basic usage guidance and build instructions.
- Cover both the CLI (`tmd-cli`) and the FFI wrapper (`tmd-core-ffi`) because they previously lacked READMEs.

### Description

- Added `tmd-cli/README.md` documenting build/run commands, available subcommands, and examples for creating, converting, validating, exporting, and DB operations. 
- Added `tmd-core-ffi/README.md` describing how to build the cdylib, expected output filenames per platform, and the commonly exported FFI symbols. 
- Files were staged and committed as part of the documentation update.

### Testing

- No automated tests were executed for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69775c7495e083289892116e90ae965a)