### PR TITLE
docs: remove decorative emojis from documentation

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,4 +1,4 @@
-# 🐾 Tanu Markdown — Project Status
+# Tanu Markdown — Project Status
 
 _Last updated: 2025-10-09 (rev.1: SQLite moved to MVP)_
 
@@ -59,20 +59,20 @@ _Last updated: 2025-10-09 (rev.1: SQLite moved to MVP)_
 
 ## 現在の進行状況
 
-### ✅ 実装済み
+### 実装済み
 - `.tmd` 読み取り（MarkdownとZIPの分離）
   - EOCD検出・コメント解析 (`find_eocd_offset`)
   - Markdownサイズ取得・分離 (`split_tmd_bytes`)
   - manifestのサイズ／SHA256検証
   - ZIPコメント再設定ユーティリティ (`set_tmd_comment`)
 
-### 🚧 進行中
+### 進行中
 - `.tmd` 書き出しロジック (`to_bytes()`, `to_tmdz_bytes()`)
 - CLI MVP構築（`pack/unpack/validate/export-html`）
 - SQLite埋め込み基盤（読み取り専用）
 - VSCode拡張スタブ（コマンドスケルトン）
 
-### 💤 未着手
+### 未着手
 - formal spec ドキュメント
 - CIによる往復テスト
 - SQL安全モード評価（後期フェーズ）
@@ -81,39 +81,39 @@ _Last updated: 2025-10-09 (rev.1: SQLite moved to MVP)_
 
 ## 今後のタスク（優先度順）
 
-### 1️⃣ コア書き出し (`.tmd` 生成)
+### 1. コア書き出し (`.tmd` 生成)
 - Markdown + ZIP + EOCDコメント統合
-- `.tmdz` ↔ `.tmd` 相互変換
+- `.tmdz` と `.tmd` 相互変換
 - SQLiteファイル (`db/main.sqlite`) 埋め込み対応
 - 大容量ファイル対応（ストリーミングZipWriter）
 
-### 2️⃣ CLI MVP
+### 2. CLI MVP
 - `tmd new` — プロジェクト雛形生成  
 - `tmd pack/unpack` — フォーマット相互変換  
 - `tmd validate` — manifest・SQLite整合性検証  
 - `tmd export-html` — 自己完結HTML出力  
 - `tmd query` — `.tmd` 内 SQLite に対する読み取りクエリ実行（read-only）  
 
-### 3️⃣ VSCode拡張
+### 3. VSCode拡張
 - `.tmd` 新規作成ウィザード  
 - `attach:` リンクのドラッグ&ドロップ  
 - SQLiteテーブルのプレビュー／クエリ実行UI  
 - 検証結果・エラーのUI表示  
 - CLI機能呼び出し統合  
 
-### 4️⃣ フォーマル仕様 (`docs/spec.md`)
+### 4. フォーマル仕様 (`docs/spec.md`)
 - EOCDコメント形式・エンディアン定義  
 - manifestスキーマとキー制約  
 - SQLite埋め込み時の安全仕様（読み取り専用・サイズ上限）  
 - 将来の拡張ポリシー（バージョニング）
 
-### 5️⃣ テスト・サンプル
+### 5. テスト・サンプル
 - `tmd-sample/hello-world`（最小構成）  
 - `tmd-sample/sqlite-demo`（SQLite内データ付き）  
 - 壊れたZIPや不正manifestのテストケース  
 - CIでの往復テスト（read→write→read）
 
-### 6️⃣ 将来拡張
+### 6. 将来拡張
 - SQL評価の安全モード（式評価や変数展開対応）  
 - 暗号署名ブロックによる整合性保証  
 - 完全自己完結型HTML/PDFエクスポート  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **this is very AI generated bare scaffolding. make sure this is not guaranteed to work normally.**
 
-# 🦝 Tanu Markdown (TMD)
+# Tanu Markdown (TMD)
 
 **Tanu Markdown (TMD)** is a *self-contained Markdown format* that lets you embed **images, databases, and binary data** directly into Markdown.
 
@@ -8,7 +8,7 @@ Each `.tmd` file combines **Markdown text + embedded assets + metadata (manifest
 
 ---
 
-## 📦 Repository Structure
+## Repository Structure
 
 | Directory | Description |
 |------------|-------------|
@@ -19,7 +19,7 @@ Each `.tmd` file combines **Markdown text + embedded assets + metadata (manifest
 
 ---
 
-## 🛠 Development Environment
+## Development Environment
 
 ### Run everything in Docker
 
@@ -50,7 +50,7 @@ The packaged extension only exposes a welcome command (`Tanu Markdown Editor: Sh
 
 ---
 
-## 🧩 File Format Overview
+## File Format Overview
 
 ### `.tmd` — Polyglot Format (Markdown + ZIP)
 
@@ -73,7 +73,7 @@ The packaged extension only exposes a welcome command (`Tanu Markdown Editor: Sh
 
 ---
 
-## 🧰 Components
+## Components
 
 ### `tmd-vscode/`
 **Tanu Markdown Editor**, a VS Code extension placeholder written in TypeScript. The current build only registers a welcome command so that the package can be installed and tested before real editing features arrive.
@@ -93,7 +93,7 @@ cargo run -- export-html mydoc.tmd out.html --self-contained
 
 ---
 
-## 🧱 Roadmap
+## Roadmap
 
 - [ ] Implement `.tmd` read/write logic (EOCD parsing, ZIP build)
 - [ ] Attachment management UI in VSCode extension
@@ -103,11 +103,11 @@ cargo run -- export-html mydoc.tmd out.html --self-contained
 
 ---
 
-## 📜 License
+## License
 
 MIT License  
 (c) 2025 Tanu Markdown Project
 
 ---
 
-🧡 *Tanu Markdown — Markdown that packs everything inside.*
+*Tanu Markdown — Markdown that packs everything inside.*

--- a/README_JP.md
+++ b/README_JP.md
@@ -1,4 +1,4 @@
-# 🦝 Tanu Markdown (TMD)
+# Tanu Markdown (TMD)
 
 **Tanu Markdown (TMD)** は、通常の Markdown ファイルに **画像・データベース・添付リソースを同梱できる**
 「自己完結型ドキュメント形式」を目指す新しい仕様です。
@@ -8,7 +8,7 @@ TMD は `.tmd` 拡張子を持ち、1 つのファイルに **Markdown本文 + �
 
 ---
 
-## 📦 構成概要
+## 構成概要
 
 | ディレクトリ | 内容 |
 |--------------|------|
@@ -19,7 +19,7 @@ TMD は `.tmd` 拡張子を持ち、1 つのファイルに **Markdown本文 + �
 
 ---
 
-## 🛠 開発環境
+## 開発環境
 
 ### Docker でまとめて構築する
 
@@ -50,7 +50,7 @@ VS Code の **Dev Containers** 拡張機能を利用すると、同じイメー�
 
 ---
 
-## 🧩 ファイル形式概要
+## ファイル形式概要
 
 ### `.tmd` — Polyglot 形式 (Markdown + ZIP)
 
@@ -73,7 +73,7 @@ VS Code の **Dev Containers** 拡張機能を利用すると、同じイメー�
 
 ---
 
-## 🧰 各コンポーネント
+## 各コンポーネント
 
 ### `tmd-vscode/`
 TypeScript 製の VSCode 拡張「Tanu Markdown Editor」のプレースホルダーです。現状はウェルカムコマンドのみを登録しており、将来的な編集機能を追加するための土台となります。
@@ -93,7 +93,7 @@ cargo run -- export-html mydoc.tmd out.html --self-contained
 
 ---
 
-## 🧱 今後の展開
+## 今後の展開
 
 - [ ] `.tmd` 読み書き処理の実装
 - [ ] VSCode 拡張での添付管理 UI
@@ -103,11 +103,11 @@ cargo run -- export-html mydoc.tmd out.html --self-contained
 
 ---
 
-## 📜 ライセンス
+## ライセンス
 
 MIT License  
 (c) 2025 Tanu Markdown Project
 
 ---
 
-🧡 *Tanu Markdown — Markdown that packs everything inside.*
+*Tanu Markdown — Markdown that packs everything inside.*


### PR DESCRIPTION
## Summary
- Removed decorative emojis from documentation in , , and .
- This is a documentation-only cleanup to keep style plain and neutral.

## Scope
- Scope is intentionally limited to docs files in tanu-markdown.
- No behavior or code changes.
