### PR TITLE
chore: ignore OS junk files

### DIFF
--- a/tmd-sample/.gitignore
+++ b/tmd-sample/.gitignore
@@ -9,3 +9,14 @@ generated/
 # Sample data that shouldn't be tracked
 *.large
 *.test
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+.AppleDouble
+ehthumbs.db
+Thumbs.db
+desktop.ini

--- a/tmd-vscode/.gitignore
+++ b/tmd-vscode/.gitignore
@@ -27,3 +27,14 @@ coverage/
 # VS Code specific
 .vscode/settings.json
 .vscode/launch.json
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+.AppleDouble
+ehthumbs.db
+Thumbs.db
+desktop.ini


### PR DESCRIPTION
## Summary
- Add OS-generated files to .gitignore in tmd-sample and tmd-vscode.
- Covers `.DS_Store`, `._*`, `.AppleDouble`, `.Spotlight-V100`, `.Trashes`, `Thumbs.db`, `ehthumbs.db`, `desktop.ini`.